### PR TITLE
Fix insta_dl import and runtime errors

### DIFF
--- a/bot/pkgs/insta_dl.py
+++ b/bot/pkgs/insta_dl.py
@@ -225,7 +225,7 @@ async def _get_embed_media(session: aiohttp.ClientSession, shortcode: str) -> di
         ctx_json = json.loads(ctx_json_raw)
     else:
         raise RuntimeError(f"Unexpected contextJSON type: {
-                type(ctx_json_raw)}")
+            type(ctx_json_raw)}")
 
     gql_data = ctx_json.get("gql_data")
     if not gql_data:

--- a/bot/utils/insta_dl_utils.py
+++ b/bot/utils/insta_dl_utils.py
@@ -1,3 +1,4 @@
+import json
 import math
 import os
 import secrets
@@ -8,7 +9,7 @@ from typing import Optional
 
 from bot.config import bot, conf
 from bot.fun.emojis import enhearts
-from bot.pkg.insta_dl import download_instagram
+from bot.pkgs.insta_dl import download_instagram
 
 from .bot_utils import (
     hbs,
@@ -74,6 +75,10 @@ class InstagramHelper:
     @property
     def name(self):
         return self._listener.name
+
+    @property
+    def download_is_complete(self):
+        return self._listener.completed
 
     async def _on_download_progress(self, current: int, total: int, file_path: str):
         """Called after each chunk; updates internal state and edits the message."""

--- a/bot/utils/insta_dl_utils.py
+++ b/bot/utils/insta_dl_utils.py
@@ -136,7 +136,7 @@ class InstagramHelper:
         await event.react("✅")
         self._listener.is_cancelled = True
         self._on_download_error(f"Download with gid: {
-                self._gid} was cancelled.")
+            self._gid} was cancelled.")
         await self.clean_up()
 
     async def clean_up(self):

--- a/bot/workers/handlers/yt.py
+++ b/bot/workers/handlers/yt.py
@@ -5,7 +5,7 @@ from clean_links.clean import clean_url
 from urlextract import URLExtract
 
 from bot.config import bot
-from bot.pkg.insta_dl import is_valid_instagram_url
+from bot.pkgs.insta_dl import is_valid_instagram_url
 from bot.utils.bot_utils import png_to_jpg, sync_to_async
 from bot.utils.insta_dl_utils import InstagramHelper as InstagramDLHelper
 from bot.utils.insta_dl_utils import Listener as InstaListener
@@ -104,15 +104,15 @@ async def youtube_reply(event, args, client):
         if not supported_links:
             return
         job = list(supported_links)
+        t_args = extract_bracketed_prefix(text)
         while job:
             try:
                 listener = DummyListener(job[0])
                 if is_valid_instagram_url(listener.link):
-                    if await insta_reply(event, listener.link):
+                    if await insta_reply(event, listener.link, t_args):
                         job.pop(0)
                         continue
                 audio = False
-                t_args = None
                 twi = False
                 _format = "bv*[ext=mp4][vcodec~='h264|avc1'][filesize<100M][height<={0}]+ba[ext=m4a]/b[ext=mp4][vcodec~='h264|avc1'][filesize<100M][height<={0}] / bv*+ba/b"
                 _alt_format = "bv*[ext=mp4][vcodec~='h264|avc1'][height<={0}]+ba/b[ext=mp4][vcodec~='h264|avc1'][height<={0}] / bv*+ba/b"
@@ -140,9 +140,7 @@ async def youtube_reply(event, args, client):
                 if result.get("is_live") or result.get("live_status") == "live":
                     return await event.reply("*It's a Live video XD*")
                 playlist = "entries" in result
-                if not (trimmed or playlist) and (
-                    t_args := extract_bracketed_prefix(text)
-                ):
+                if not (trimmed or playlist) and t_args:
                     trimmed = True
                     if not is_valid_trim_args(t_args, total_dur=result.get("duration")):
                         (
@@ -209,7 +207,7 @@ async def youtube_reply(event, args, client):
         await event.react("❌")
 
 
-async def insta_reply(event, link) -> bool:
+async def insta_reply(event, link, t_args=None) -> bool:
     listener = InstaListener(link)
     insta_dl = InstagramDLHelper(listener)
     status_msg = await event.reply("*Downloading…*")


### PR DESCRIPTION
This PR fixes several issues with the Instagram downloader (insta_dl):
1. **Import Errors**: Corrected the module path from `bot.pkg.insta_dl` to `bot.pkgs.insta_dl` in both `yt.py` handler and `insta_dl_utils.py`.
2. **Missing Imports**: Added `import json` to `insta_dl_utils.py` which was used but not imported.
3. **Missing Property**: Added the `download_is_complete` property to the `InstagramHelper` class, which was being accessed by the handler but was not defined.
4. **Runtime Errors**: Fixed an `UnboundLocalError` for `t_args` in `bot/workers/handlers/yt.py` by extracting the bracketed prefix once and passing it correctly to the `insta_reply` function.

---
*PR created automatically by Jules for task [15051845583325773539](https://jules.google.com/task/15051845583325773539) started by @Nubuki-all*