### PR TITLE
Add Ace Attorney video generator handler

### DIFF
--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -45,6 +45,7 @@ from .workers.handlers.manage import (
     ytdl_enable,
 )
 from .workers.handlers.media_dl import youtube_reply
+from .workers.handlers.objection import insession, render_objection
 from .workers.handlers.role import roles
 from .workers.handlers.stuff import gc_info, getcmds, hello, up
 from .workers.handlers.wa import gc_handler, handle_self_join, sticker_reply
@@ -228,6 +229,16 @@ async def _(client: NewAClient, message: Event):
 @bot.register("update")
 async def _(client: NewAClient, message: Event):
     await event_handler(message, update_handler)
+
+
+@bot.register("insession")
+async def _(client: NewAClient, message: Event):
+    await event_handler(message, insession)
+
+
+@bot.register("renderobj")
+async def _(client: NewAClient, message: Event):
+    await event_handler(message, render_objection)
 
 
 @bot.register("restart")

--- a/bot/utils/msg_store.py
+++ b/bot/utils/msg_store.py
@@ -213,7 +213,7 @@ async def get_messages_between(chat_id: str, start_id: str, end_id: str):
                 .where(
                     and_(
                         Message.chat_id == chat_id,
-                        Message.visible,
+                        Message.visible == True,
                         Message.timestamp >= min_ts,
                         Message.timestamp <= max_ts,
                     )

--- a/bot/utils/msg_store.py
+++ b/bot/utils/msg_store.py
@@ -194,6 +194,38 @@ async def get_messages_by_album_id(chat_id: str, album_id: str, limit: int = 100
         raise e
 
 
+async def get_messages_between(chat_id: str, start_id: str, end_id: str):
+    try:
+        async with async_session() as session:
+            stmt_start = select(Message.timestamp).where(
+                and_(Message.chat_id == chat_id, Message.id == start_id)
+            )
+            stmt_end = select(Message.timestamp).where(
+                and_(Message.chat_id == chat_id, Message.id == end_id)
+            )
+            ts_start = (await session.execute(stmt_start)).scalar()
+            ts_end = (await session.execute(stmt_end)).scalar()
+            if ts_start is None or ts_end is None:
+                return []
+            min_ts, max_ts = min(ts_start, ts_end), max(ts_start, ts_end)
+            stmt = (
+                select(Message)
+                .where(
+                    and_(
+                        Message.chat_id == chat_id,
+                        Message.visible == True,
+                        Message.timestamp >= min_ts,
+                        Message.timestamp <= max_ts,
+                    )
+                )
+                .order_by(Message.timestamp.asc())
+            )
+            results = (await session.scalars(stmt)).all()
+        return [construct_event(load_proto(msg_data.raw)) for msg_data in results]
+    except Exception as e:
+        raise e
+
+
 async def auto_save_msg():
     bot.auto_save_msg_is_running = True
     while True:

--- a/bot/utils/msg_store.py
+++ b/bot/utils/msg_store.py
@@ -213,7 +213,7 @@ async def get_messages_between(chat_id: str, start_id: str, end_id: str):
                 .where(
                     and_(
                         Message.chat_id == chat_id,
-                        Message.visible == True,
+                        Message.visible,
                         Message.timestamp >= min_ts,
                         Message.timestamp <= max_ts,
                     )

--- a/bot/workers/handlers/objection.py
+++ b/bot/workers/handlers/objection.py
@@ -1,0 +1,106 @@
+import asyncio
+import os
+import shutil
+import time
+from objection_engine.beans.comment import Comment
+from objection_engine.renderer import render_comment_list
+
+from bot import bot, heavy_proc_lock
+from bot.utils.log_utils import logger
+from bot.utils.msg_store import get_messages_between
+
+objection_sessions = {}
+
+async def insession(event, args, client):
+    """
+    Starts an objection session by marking the current message (or the replied message) as the starting point.
+    Usage: /insession
+    """
+    chat_id = event.chat.id
+    start_msg_id = event.reply_to_message.id if event.reply_to_message else event.id
+
+    objection_sessions[chat_id] = {
+        "start_id": start_msg_id,
+        "time": time.time()
+    }
+
+    await event.reply(
+        f"Objection session started from message ID: `{start_msg_id}`.\n"
+        "Reply to the ending message with `/renderobj` to generate the video.\n"
+        "Session expires in 300 seconds."
+    )
+
+async def render_objection(event, args, client):
+    """
+    Renders the objection video for the messages between the start point and the replied message.
+    Usage: /renderobj (replying to the end message)
+    """
+    chat_id = event.chat.id
+    session = objection_sessions.get(chat_id)
+
+    if not session:
+        return await event.reply("No active objection session in this chat. Start one with `/insession`.")
+
+    if time.time() - session["time"] > 300:
+        del objection_sessions[chat_id]
+        return await event.reply("Objection session timed out. Start a new one with `/insession`.")
+
+    end_msg_id = event.reply_to_message.id if event.reply_to_message else event.id
+    start_id = session["start_id"]
+
+    del objection_sessions[chat_id]
+
+    async with event.react("🎬"):
+        try:
+            messages = await get_messages_between(chat_id, start_id, end_msg_id)
+            if not messages:
+                return await event.reply("No messages found in the specified range.")
+
+            comments = []
+            temp_dir = f"temp_objection_{chat_id}_{int(time.time())}"
+            os.makedirs(temp_dir, exist_ok=True)
+
+            for msg in messages:
+                user_name = msg.from_user.name or "User"
+                user_id = msg.from_user.id
+                text = msg.text or msg.caption or ""
+                evidence_path = None
+
+                if msg.image:
+                    img_path = os.path.join(temp_dir, f"evidence_{msg.id}.jpg")
+                    await msg.download(img_path)
+                    evidence_path = img_path
+                    evidence_paths.append(img_path)
+
+                if text or evidence_path:
+                    comments.append(Comment(
+                        user_id=user_id,
+                        user_name=user_name,
+                        text_content=text if text else " ",
+                        evidence_path=evidence_path
+                    ))
+
+            if not comments:
+                return await event.reply("No valid text or image messages found in the range.")
+
+            output_file = os.path.join(temp_dir, "objection_video.mp4")
+
+            async with heavy_proc_lock:
+                # render_comment_list is likely synchronous and heavy
+                loop = asyncio.get_event_loop()
+                await loop.run_in_executor(
+                    None,
+                    lambda: render_comment_list(comments, output_filename=output_file)
+                )
+
+            if os.path.exists(output_file):
+                await event.reply_video(output_file, caption="Here is your objection video!")
+            else:
+                await event.reply("Failed to generate objection video.")
+
+        except Exception as e:
+            await logger(e)
+            await event.reply(f"An error occurred: {e}")
+        finally:
+            if os.path.exists(temp_dir):
+                shutil.rmtree(temp_dir)

--- a/bot/workers/handlers/objection.py
+++ b/bot/workers/handlers/objection.py
@@ -2,14 +2,16 @@ import asyncio
 import os
 import shutil
 import time
+
 from objection_engine.beans.comment import Comment
 from objection_engine.renderer import render_comment_list
 
-from bot import bot, heavy_proc_lock, conf
+from bot import conf, heavy_proc_lock
 from bot.utils.log_utils import logger
 from bot.utils.msg_store import get_messages_between
 
 objection_sessions = {}
+
 
 async def insession(event, args, client):
     """
@@ -19,16 +21,14 @@ async def insession(event, args, client):
     chat_id = event.chat.id
     start_msg_id = event.reply_to_message.id if event.reply_to_message else event.id
 
-    objection_sessions[chat_id] = {
-        "start_id": start_msg_id,
-        "time": time.time()
-    }
+    objection_sessions[chat_id] = {"start_id": start_msg_id, "time": time.time()}
 
     await event.reply(
         f"Objection session started from message ID: `{start_msg_id}`.\n"
         f"Reply to the ending message with `{conf.CMD_PREFIX}renderobj` to generate the video.\n"
         "Session expires in 300 seconds."
     )
+
 
 async def render_objection(event, args, client):
     """
@@ -39,11 +39,15 @@ async def render_objection(event, args, client):
     session = objection_sessions.get(chat_id)
 
     if not session:
-        return await event.reply(f"No active objection session in this chat. Start one with `{conf.CMD_PREFIX}insession`.")
+        return await event.reply(
+            f"No active objection session in this chat. Start one with `{conf.CMD_PREFIX}insession`."
+        )
 
     if time.time() - session["time"] > 300:
         del objection_sessions[chat_id]
-        return await event.reply(f"Objection session timed out. Start a new one with `{conf.CMD_PREFIX}insession`.")
+        return await event.reply(
+            f"Objection session timed out. Start a new one with `{conf.CMD_PREFIX}insession`."
+        )
 
     end_msg_id = event.reply_to_message.id if event.reply_to_message else event.id
     start_id = session["start_id"]
@@ -61,7 +65,9 @@ async def render_objection(event, args, client):
             os.makedirs(temp_dir, exist_ok=True)
 
             for msg in messages:
-                is_image = msg.image or (msg.document and msg.document.mimetype.startswith("image"))
+                is_image = msg.image or (
+                    msg.document and msg.document.mimetype.startswith("image")
+                )
                 if not (msg.text or is_image):
                     continue
 
@@ -75,15 +81,19 @@ async def render_objection(event, args, client):
                     await msg.download(img_path)
                     evidence_path = img_path
 
-                comments.append(Comment(
-                    user_id=user_id,
-                    user_name=user_name,
-                    text_content=text,
-                    evidence_path=evidence_path
-                ))
+                comments.append(
+                    Comment(
+                        user_id=user_id,
+                        user_name=user_name,
+                        text_content=text,
+                        evidence_path=evidence_path,
+                    )
+                )
 
             if not comments:
-                return await event.reply("No valid text or image messages found in the range.")
+                return await event.reply(
+                    "No valid text or image messages found in the range."
+                )
 
             output_file = os.path.join(temp_dir, "objection_video.mp4")
 
@@ -92,11 +102,13 @@ async def render_objection(event, args, client):
                 loop = asyncio.get_event_loop()
                 await loop.run_in_executor(
                     None,
-                    lambda: render_comment_list(comments, output_filename=output_file)
+                    lambda: render_comment_list(comments, output_filename=output_file),
                 )
 
             if os.path.exists(output_file):
-                await event.reply_video(output_file, caption="Here is your objection video!")
+                await event.reply_video(
+                    output_file, caption="Here is your objection video!"
+                )
             else:
                 await event.reply("Failed to generate objection video.")
 

--- a/bot/workers/handlers/objection.py
+++ b/bot/workers/handlers/objection.py
@@ -2,16 +2,14 @@ import asyncio
 import os
 import shutil
 import time
-
 from objection_engine.beans.comment import Comment
 from objection_engine.renderer import render_comment_list
 
-from bot import heavy_proc_lock
+from bot import bot, heavy_proc_lock, conf
 from bot.utils.log_utils import logger
 from bot.utils.msg_store import get_messages_between
 
 objection_sessions = {}
-
 
 async def insession(event, args, client):
     """
@@ -21,14 +19,16 @@ async def insession(event, args, client):
     chat_id = event.chat.id
     start_msg_id = event.reply_to_message.id if event.reply_to_message else event.id
 
-    objection_sessions[chat_id] = {"start_id": start_msg_id, "time": time.time()}
+    objection_sessions[chat_id] = {
+        "start_id": start_msg_id,
+        "time": time.time()
+    }
 
     await event.reply(
         f"Objection session started from message ID: `{start_msg_id}`.\n"
-        "Reply to the ending message with `/renderobj` to generate the video.\n"
+        f"Reply to the ending message with `{conf.CMD_PREFIX}renderobj` to generate the video.\n"
         "Session expires in 300 seconds."
     )
-
 
 async def render_objection(event, args, client):
     """
@@ -39,15 +39,11 @@ async def render_objection(event, args, client):
     session = objection_sessions.get(chat_id)
 
     if not session:
-        return await event.reply(
-            "No active objection session in this chat. Start one with `/insession`."
-        )
+        return await event.reply(f"No active objection session in this chat. Start one with `{conf.CMD_PREFIX}insession`.")
 
     if time.time() - session["time"] > 300:
         del objection_sessions[chat_id]
-        return await event.reply(
-            "Objection session timed out. Start a new one with `/insession`."
-        )
+        return await event.reply(f"Objection session timed out. Start a new one with `{conf.CMD_PREFIX}insession`.")
 
     end_msg_id = event.reply_to_message.id if event.reply_to_message else event.id
     start_id = session["start_id"]
@@ -65,31 +61,29 @@ async def render_objection(event, args, client):
             os.makedirs(temp_dir, exist_ok=True)
 
             for msg in messages:
+                is_image = msg.image or (msg.document and msg.document.mimetype.startswith("image"))
+                if not (msg.text or is_image):
+                    continue
+
                 user_name = msg.from_user.name or "User"
                 user_id = msg.from_user.id
-                text = msg.text or msg.caption or ""
+                text = msg.text or msg.caption or "..."
                 evidence_path = None
 
-                if msg.image:
+                if is_image:
                     img_path = os.path.join(temp_dir, f"evidence_{msg.id}.jpg")
                     await msg.download(img_path)
                     evidence_path = img_path
-                    evidence_paths.append(img_path)
 
-                if text or evidence_path:
-                    comments.append(
-                        Comment(
-                            user_id=user_id,
-                            user_name=user_name,
-                            text_content=text if text else " ",
-                            evidence_path=evidence_path,
-                        )
-                    )
+                comments.append(Comment(
+                    user_id=user_id,
+                    user_name=user_name,
+                    text_content=text,
+                    evidence_path=evidence_path
+                ))
 
             if not comments:
-                return await event.reply(
-                    "No valid text or image messages found in the range."
-                )
+                return await event.reply("No valid text or image messages found in the range.")
 
             output_file = os.path.join(temp_dir, "objection_video.mp4")
 
@@ -98,13 +92,11 @@ async def render_objection(event, args, client):
                 loop = asyncio.get_event_loop()
                 await loop.run_in_executor(
                     None,
-                    lambda: render_comment_list(comments, output_filename=output_file),
+                    lambda: render_comment_list(comments, output_filename=output_file)
                 )
 
             if os.path.exists(output_file):
-                await event.reply_video(
-                    output_file, caption="Here is your objection video!"
-                )
+                await event.reply_video(output_file, caption="Here is your objection video!")
             else:
                 await event.reply("Failed to generate objection video.")
 

--- a/bot/workers/handlers/objection.py
+++ b/bot/workers/handlers/objection.py
@@ -2,14 +2,16 @@ import asyncio
 import os
 import shutil
 import time
+
 from objection_engine.beans.comment import Comment
 from objection_engine.renderer import render_comment_list
 
-from bot import bot, heavy_proc_lock
+from bot import heavy_proc_lock
 from bot.utils.log_utils import logger
 from bot.utils.msg_store import get_messages_between
 
 objection_sessions = {}
+
 
 async def insession(event, args, client):
     """
@@ -19,16 +21,14 @@ async def insession(event, args, client):
     chat_id = event.chat.id
     start_msg_id = event.reply_to_message.id if event.reply_to_message else event.id
 
-    objection_sessions[chat_id] = {
-        "start_id": start_msg_id,
-        "time": time.time()
-    }
+    objection_sessions[chat_id] = {"start_id": start_msg_id, "time": time.time()}
 
     await event.reply(
         f"Objection session started from message ID: `{start_msg_id}`.\n"
         "Reply to the ending message with `/renderobj` to generate the video.\n"
         "Session expires in 300 seconds."
     )
+
 
 async def render_objection(event, args, client):
     """
@@ -39,11 +39,15 @@ async def render_objection(event, args, client):
     session = objection_sessions.get(chat_id)
 
     if not session:
-        return await event.reply("No active objection session in this chat. Start one with `/insession`.")
+        return await event.reply(
+            "No active objection session in this chat. Start one with `/insession`."
+        )
 
     if time.time() - session["time"] > 300:
         del objection_sessions[chat_id]
-        return await event.reply("Objection session timed out. Start a new one with `/insession`.")
+        return await event.reply(
+            "Objection session timed out. Start a new one with `/insession`."
+        )
 
     end_msg_id = event.reply_to_message.id if event.reply_to_message else event.id
     start_id = session["start_id"]
@@ -73,15 +77,19 @@ async def render_objection(event, args, client):
                     evidence_paths.append(img_path)
 
                 if text or evidence_path:
-                    comments.append(Comment(
-                        user_id=user_id,
-                        user_name=user_name,
-                        text_content=text if text else " ",
-                        evidence_path=evidence_path
-                    ))
+                    comments.append(
+                        Comment(
+                            user_id=user_id,
+                            user_name=user_name,
+                            text_content=text if text else " ",
+                            evidence_path=evidence_path,
+                        )
+                    )
 
             if not comments:
-                return await event.reply("No valid text or image messages found in the range.")
+                return await event.reply(
+                    "No valid text or image messages found in the range."
+                )
 
             output_file = os.path.join(temp_dir, "objection_video.mp4")
 
@@ -90,11 +98,13 @@ async def render_objection(event, args, client):
                 loop = asyncio.get_event_loop()
                 await loop.run_in_executor(
                     None,
-                    lambda: render_comment_list(comments, output_filename=output_file)
+                    lambda: render_comment_list(comments, output_filename=output_file),
                 )
 
             if os.path.exists(output_file):
-                await event.reply_video(output_file, caption="Here is your objection video!")
+                await event.reply_video(
+                    output_file, caption="Here is your objection video!"
+                )
             else:
                 await event.reply("Failed to generate objection video.")
 


### PR DESCRIPTION
This PR introduces a new feature to generate Ace Attorney style "objection" videos from WhatsApp messages.

Key changes:
1. **Message Store Enhancement**: Added `get_messages_between` to `bot/utils/msg_store.py` which allows retrieving all messages between two message IDs based on their timestamps.
2. **New Handler**: Created `bot/workers/handlers/objection.py` containing:
    - `/insession`: Marks the starting point of the conversation for the video.
    - `/renderobj`: (Used when replying to the end message) Collects the messages in the range, downloads images for evidence, and uses `objection_engine` to render the final video.
3. **Integration**: Registered the new commands in `bot/__main__.py`.
4. **Performance**: Rendering is executed in a thread pool and synchronized with `heavy_proc_lock` to avoid blocking the bot's event loop.
5. **Cleanup**: Temporary files and evidence are automatically deleted after rendering.

---
*PR created automatically by Jules for task [15305166343128483016](https://jules.google.com/task/15305166343128483016) started by @Nubuki-all*